### PR TITLE
fix: convert errors when files are up to date

### DIFF
--- a/.github/workflows/update-formulas.yaml
+++ b/.github/workflows/update-formulas.yaml
@@ -3,7 +3,7 @@ on:
   push:
     paths:
       - 'formulas/**.amath'
-      - '.github/workflows/'
+      - '.github/workflows/**.yaml'
 jobs:
   update-formulas:
     runs-on: ubuntu-24.04
@@ -29,6 +29,9 @@ jobs:
         run: |
           git config --global user.name 'Austromo'
           git config --global user.email 'Austromo@users.noreply.github.com'
-          git add img/
-          git commit -m "[bot] automated formula conversion"
-          git push
+          # check if any tracked files have been updated
+          if ! [[ -z $(git status -uno --porcelain) ]]; then 
+            git add img/
+            git commit -m "[bot] automated formula conversion"
+            git push
+          fi


### PR DESCRIPTION
This is a follow up to #1 
Under certain circumstances (e.g. when the workflow file is changed or on pr merge :wink:) the action would be run even though the image files are up to date. 
Running `git commit` would then return a nonzero status code and make the entire action fail.

Sorry for that :sweat_smile: 